### PR TITLE
Fix code scanning alert no. 21: Uncontrolled data used in path expression

### DIFF
--- a/api/api/files.py
+++ b/api/api/files.py
@@ -29,6 +29,7 @@
 """This module defines the API routes for file management."""
 
 from flask import Blueprint, jsonify, request, send_file
+from werkzeug.utils import secure_filename
 from google.cloud import storage
 import os
 from api.auth import auth
@@ -74,7 +75,8 @@ def download_file(filename):
         return jsonify({"error": f"File '{filename}' not found"}), 404
 
     # Create a temporary file to store the downloaded content
-    temp_filename = f"/tmp/{filename}"
+    safe_filename = secure_filename(filename)
+    temp_filename = os.path.join("/tmp", safe_filename)
     blob.download_to_filename(temp_filename)
 
     # Send the downloaded file to the client


### PR DESCRIPTION
Fixes [https://github.com/google/litmus/security/code-scanning/21](https://github.com/google/litmus/security/code-scanning/21)

To fix the problem, we need to ensure that the `filename` parameter is sanitized and validated before it is used to construct the `temp_filename`. We can use the `werkzeug.utils.secure_filename` function to sanitize the filename, ensuring it does not contain any special characters or path traversal sequences. Additionally, we should normalize the path to ensure it stays within the intended directory.

1. Import the `secure_filename` function from `werkzeug.utils`.
2. Use `secure_filename` to sanitize the `filename` parameter.
3. Construct the `temp_filename` using the sanitized filename.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
